### PR TITLE
Scrollable menu eta itzulpen konponketak.

### DIFF
--- a/app/Resources/translations/messages.es.xliff
+++ b/app/Resources/translations/messages.es.xliff
@@ -8,7 +8,7 @@
             </trans-unit>
             <trans-unit id="2">
                 <source>G.A.O. Argitaratze Data</source>
-                <target>Fecha publicación B.O.G.</target>
+                <target>Fecha publicación en B.O.</target>
             </trans-unit>
             <trans-unit id="3">
                 <source>Aldaketak</source>
@@ -56,7 +56,7 @@
             </trans-unit>
             <trans-unit id="14">
                 <source>B.O.G. argitaratze data</source>
-                <target>Fecha publicación B.O.G.</target>
+                <target>Fecha publicación en el boletín oficial</target>
             </trans-unit>
             <trans-unit id="15">
                 <source>Indarrean data</source>
@@ -99,11 +99,11 @@
                 <target>Obtener Odt</target>
             </trans-unit>
             <trans-unit id="25">
-                <source>B.O.G. esteka eskaraz</source>
+                <source>G.A.O. esteka eskaraz</source>
                 <target>B.O.G. esteka eskaraz</target>
             </trans-unit>
             <trans-unit id="26">
-                <source>B.O.G. esteka erdaraz</source>
+                <source>G.A.O. esteka erdaraz</source>
                 <target>B.O.G. esteka erdaraz</target>
             </trans-unit>
         </body>

--- a/app/Resources/translations/messages.es.yml
+++ b/app/Resources/translations/messages.es.yml
@@ -1,5 +1,5 @@
 'Onartze data': 'Fecha aceptación'
-'G.A.O. Argitaratze Data': 'Fecha publicación B.O.G.'
+'G.A.O. Argitaratze Data': 'Fecha publicación B.O.'
 Aldaketak: Cambios
 Fitxategia: Fichero
 Historikoa: Historico
@@ -11,10 +11,10 @@ Unitatea: Unidad
 'Ordenantza ikusi': 'Ver ordenanza'
 Itxi: Cerrar
 'Onartze Data': 'Fecha aceptación'
-'B.O.G. argitaratze data': 'Fecha publicación B.O.G.'
+'B.O.G. argitaratze data': 'Fecha publicación en el B.O.'
 'Indarrean data': 'Fecha Vigor'
-'B.O.G. esteka eskaraz': 'B.O.G. esteka eskaraz'
-'B.O.G. esteka erdaraz': 'B.O.G. esteka erdaraz'
+'B.O.G. esteka eskaraz': 'Enlace al B.O. en euskera'
+'B.O.G. esteka erdaraz': 'Enlace al B.O. en castellano'
 'Aldaketak euskaraz': 'Cambios en euskera'
 'Aldaketak erdaraz': 'Cambios en castellano'
 'Kodea:': 'Código:'
@@ -24,7 +24,7 @@ Itxi: Cerrar
 Ezabatu: Eliminar
 'Aldaketak ezeztatu': 'Deshacer los cambios'
 'Udalbatzarrararen data': 'Fecha Pleno Municipal'
-'GAO: Hasierako onarpena': 'BOG: Aprobación inicial'
+'GAO: Hasierako onarpena': 'B.O.: Aprobacion Inicial'
 'Indarreko data': 'Fecha en vigor'
 Gorde: Guardar
 Ezeztatu: Cancelar
@@ -56,5 +56,6 @@ Multzokatzea: Agrupar
 Kopiatu: Copiar
 Kopiatua!: Copiado!
 'Erabili Ctrl + C kopiatzeko': '  Utiliza Ctrl + C para copiar'
-'gao.b.b': ' BOG: Aprobación definitiva'
+'gao.b.b': 'B.O.: Aprobación definitiva'
+'GAO: Behin betiko onarpena': 'B.O.: Aprobación definitiva'
 'Akats zuzenketak (testua)': '  Corrección de errores (testo)'

--- a/app/Resources/translations/messages.eu.xliff
+++ b/app/Resources/translations/messages.eu.xliff
@@ -8,7 +8,7 @@
             </trans-unit>
             <trans-unit id="2">
                 <source>G.A.O. Argitaratze Data</source>
-                <target>G.A.O. Argitaratze Data</target>
+                <target>Argitaratze Data aldizkari ofizialean</target>
             </trans-unit>
             <trans-unit id="3">
                 <source>Aldaketak</source>
@@ -95,12 +95,12 @@
                 <target>Indarrean data</target>
             </trans-unit>
             <trans-unit id="24">
-                <source>B.O.G. esteka eskaraz</source>
-                <target>B.O.G. esteka eskaraz</target>
+                <source>G.A.O. esteka eskaraz</source>
+                <target>B.O. esteka eskaraz</target>
             </trans-unit>
             <trans-unit id="25">
-                <source>B.O.G. esteka erdaraz</source>
-                <target>B.O.G. esteka erdaraz</target>
+                <source>G.A.O. esteka erdaraz</source>
+                <target>B.O. esteka erdaraz</target>
             </trans-unit>
             <trans-unit id="26">
                 <source>Aldaketak euskaraz</source>

--- a/app/Resources/translations/messages.eu.yml
+++ b/app/Resources/translations/messages.eu.yml
@@ -1,5 +1,5 @@
 'Onartze data': 'Onartze data'
-'G.A.O. Argitaratze Data': 'G.A.O. Argitaratze Data'
+'G.A.O. Argitaratze Data': 'B.O Argitaratze Data'
 Aldaketak: Aldaketak
 Fitxategia: Fitxategia
 Historikoa: Historikoa
@@ -19,10 +19,10 @@ Kopurua: Kopurua
 Unitatea: Unitatea
 Itxi: Itxi
 'Onartze Data': 'Onartze Data'
-'B.O.G. argitaratze data': 'B.O.G. argitaratze data'
+'B.O.G. argitaratze data': 'B.O. argitaratze data'
 'Indarrean data': 'Indarrean data'
-'B.O.G. esteka eskaraz': 'B.O.G. esteka eskaraz'
-'B.O.G. esteka erdaraz': 'B.O.G. esteka erdaraz'
+'B.O.G. esteka eskaraz': 'B.O. esteka eskaraz'
+'B.O.G. esteka erdaraz': 'B.O. esteka erdaraz'
 'Aldaketak euskaraz': 'Aldaketak euskaraz'
 'Aldaketak erdaraz': 'Aldaketak erdaraz'
 'Odt-a eskuratu': 'Odt-a eskuratu'
@@ -30,8 +30,9 @@ Ezabatu: Ezabatu
 'Aldaketak ezeztatu': 'Aldaketak ezeztatu'
 'Historikoa kontsultatu': 'Historikoa kontsultatu'
 'Udalbatzarrararen data': 'Udalbatzarrararen data'
-'GAO: Hasierako onarpena': 'GAO: Hasierako onarpena'
-'gao.b.b': 'GAO: Behin betiko onarpena'
+'GAO: Hasierako onarpena': 'B.O. Hasierako onarpena'
+'GAO: Behin betiko onarpena': 'B.O. Behin betiko onarpena'
+'gao.b.b': 'B.O. Behin betiko onarpena'
 'Indarreko data': 'Indarreko data'
 Gorde: Gorde
 Ezeztatu: Ezeztatu

--- a/app/Resources/views/frontend/historikoa.html.twig
+++ b/app/Resources/views/frontend/historikoa.html.twig
@@ -36,7 +36,7 @@
                         {{ historikoa.aldaketakes |raw}}
                     {% endif %}
                 </td>
-                <td><a href="{{ "/doc/" ~ udala ~ "/" ~ historikoa.fitxategia }}">PDF</a></td>
+                <td><a href="{{ app.request.getBaseURL() ~ "/doc/" ~ udala ~ "/" ~ historikoa.fitxategia }}">PDF</a></td>
             </tr>
         {% endfor %}
         </tbody>

--- a/app/Resources/views/historikoa/edit.html.twig
+++ b/app/Resources/views/historikoa/edit.html.twig
@@ -19,16 +19,16 @@
         </div>
 
         <div class="form-group field-text col-sm-3">
-            {{ form_label(edit_form.bogbehinbetikodata, ' GAO: Behin betiko onarpena'|trans, { 'label_attr': {'class': 'control-label'} }) }}
+            {{ form_label(edit_form.bogbehinbetikodata, 'GAO: Behin betiko onarpena'|trans, { 'label_attr': {'class': 'control-label'} }) }}
             {{ form_errors(edit_form.bogbehinbetikodata) }}
             {{ form_widget(edit_form.bogbehinbetikodata, {'attr': {'class': 'form-control js-datepicker'}}) }}
-            {{ form_label(edit_form.bogargitaratzedatatestua, ' Akats zuzenketak (testua)'|trans, { 'label_attr': {'class': 'control-label'} }) }}
+            {{ form_label(edit_form.bogargitaratzedatatestua, 'Akats zuzenketak (testua)'|trans, { 'label_attr': {'class': 'control-label'} }) }}
             {{ form_errors(edit_form.bogargitaratzedatatestua) }}
             {{ form_widget(edit_form.bogargitaratzedatatestua, {'attr': {'class': 'form-control'}}) }}
         </div>
 
         <div class="form-group field-text col-sm-3">
-            {{ form_label(edit_form.indarreandata, ' Indarreko data'|trans, { 'label_attr': {'class': 'control-label'} }) }}
+            {{ form_label(edit_form.indarreandata, 'Indarreko data'|trans, { 'label_attr': {'class': 'control-label'} }) }}
             {{ form_errors(edit_form.indarreandata) }}
             {{ form_widget(edit_form.indarreandata, {'attr': {'class': 'form-control js-datepicker'}}) }}
         </div>
@@ -36,25 +36,25 @@
     </div>
 
     <div class="form-group  field-text">
-        {{ form_label(edit_form.bogestekaeu, 'G.A.O. esteka eskaraz', { 'label_attr': {'class': 'control-label'} }) }}
+        {{ form_label(edit_form.bogestekaeu, 'G.A.O. esteka eskaraz'| trans, { 'label_attr': {'class': 'control-label'} }) }}
         {{ form_errors(edit_form.bogestekaeu) }}
         {{ form_widget(edit_form.bogestekaeu, {'attr': {'class': 'form-control'}}) }}
     </div>
 
     <div class="form-group  field-text">
-        {{ form_label(edit_form.bogestekaes, 'G.A.O. esteka erdaraz', { 'label_attr': {'class': 'control-label'} }) }}
+        {{ form_label(edit_form.bogestekaes, 'G.A.O. esteka erdaraz'| trans, { 'label_attr': {'class': 'control-label'} }) }}
         {{ form_errors(edit_form.bogestekaes) }}
         {{ form_widget(edit_form.bogestekaes, {'attr': {'class': 'form-control'}}) }}
     </div>
 
     <div class="form-group  field-text">
-        {{ form_label(edit_form.aldaketakeu, 'Aldaketak euskaraz', { 'label_attr': {'class': 'control-label'} }) }}
+        {{ form_label(edit_form.aldaketakeu, 'Aldaketak euskaraz'| trans, { 'label_attr': {'class': 'control-label'} }) }}
         {{ form_errors(edit_form.aldaketakeu) }}
         {{ form_widget(edit_form.aldaketakeu, {'attr': {'class': 'form-control'}}) }}
     </div>
 
     <div class="form-group  field-text">
-        {{ form_label(edit_form.aldaketakes, 'Aldaketak erdaraz', { 'label_attr': {'class': 'control-label'} }) }}
+        {{ form_label(edit_form.aldaketakes, 'Aldaketak erdaraz'| trans, { 'label_attr': {'class': 'control-label'} }) }}
         {{ form_errors(edit_form.aldaketakes) }}
         {{ form_widget(edit_form.aldaketakes, {'attr': {'class': 'form-control'}}) }}
     </div>

--- a/app/Resources/views/historikoa/new.html.twig
+++ b/app/Resources/views/historikoa/new.html.twig
@@ -4,7 +4,7 @@
     <h1>Historiko berria</h1>
 
     {{ form_start(form) }}
-
+    
     <div class="row">
         <div class="form-group  field-text col-sm-3">
             {{ form_label(form.onartzedata, 'Udalbatzarrararen data'|trans, { 'label_attr': {'class': 'control-label'} }) }}
@@ -13,22 +13,22 @@
         </div>
 
         <div class="form-group field-text col-sm-3">
-            {{ form_label(form.bogargitaratzedata, ' GAO: Hasierako onarpena'|trans, { 'label_attr': {'class': 'control-label'} }) }}
+            {{ form_label(form.bogargitaratzedata, 'GAO: Hasierako onarpena'|trans, { 'label_attr': {'class': 'control-label'} }) }}
             {{ form_errors(form.bogargitaratzedata) }}
             {{ form_widget(form.bogargitaratzedata, {'attr': {'class': 'form-control js-datepicker'}}) }}
         </div>
 
         <div class="form-group field-text col-sm-3">
-            {{ form_label(form.bogbehinbetikodata, ' GAO: Behin betiko onarpena'|trans, { 'label_attr': {'class': 'control-label'} }) }}
+            {{ form_label(form.bogbehinbetikodata, 'GAO: Behin betiko onarpena'|trans, { 'label_attr': {'class': 'control-label'} }) }}
             {{ form_errors(form.bogbehinbetikodata) }}
             {{ form_widget(form.bogbehinbetikodata, {'attr': {'class': 'form-control js-datepicker'}}) }}
-            {{ form_label(form.bogargitaratzedatatestua, ' Akats zuzenketak (testua)'|trans, { 'label_attr': {'class': 'control-label'} }) }}
+            {{ form_label(form.bogargitaratzedatatestua, 'Akats zuzenketak (testua)'|trans, { 'label_attr': {'class': 'control-label'} }) }}
             {{ form_errors(form.bogargitaratzedatatestua) }}
             {{ form_widget(form.bogargitaratzedatatestua, {'attr': {'class': 'form-control'}}) }}
         </div>
 
         <div class="form-group field-text col-sm-3">
-            {{ form_label(form.indarreandata, ' Indarreko data'|trans, { 'label_attr': {'class': 'control-label'} }) }}
+            {{ form_label(form.indarreandata, 'Indarreko data'|trans, { 'label_attr': {'class': 'control-label'} }) }}
             {{ form_errors(form.indarreandata) }}
             {{ form_widget(form.indarreandata, {'attr': {'class': 'form-control js-datepicker'}}) }}
         </div>
@@ -36,13 +36,13 @@
     </div>
 
     <div class="form-group  field-text">
-        {{ form_label(form.bogestekaeu, 'G.A.O. esteka eskaraz', { 'label_attr': {'class': 'control-label'} }) }}
+        {{ form_label(form.bogestekaeu, 'G.A.O. esteka eskaraz'|trans, { 'label_attr': {'class': 'control-label'} }) }}
         {{ form_errors(form.bogestekaeu) }}
         {{ form_widget(form.bogestekaeu, {'attr': {'class': 'form-control'}}) }}
     </div>
 
     <div class="form-group  field-text">
-        {{ form_label(form.bogestekaes, 'G.A.O. esteka erdaraz', { 'label_attr': {'class': 'control-label'} }) }}
+        {{ form_label(form.bogestekaes, 'G.A.O. esteka erdaraz'|trans, { 'label_attr': {'class': 'control-label'} }) }}
         {{ form_errors(form.bogestekaes) }}
         {{ form_widget(form.bogestekaes, {'attr': {'class': 'form-control'}}) }}
     </div>

--- a/app/Resources/views/ordenantza/show.html.twig
+++ b/app/Resources/views/ordenantza/show.html.twig
@@ -37,7 +37,7 @@
                     <li class="dropdown dropdown-submenu ">
                         <a href="#{{ atala.kodea }}" class="dropdown-toggle" data-toggle="dropdown" data-clicked="false" onclick="clickMe(this);">{{ atala.kodea }}
                             - {{ atala.izenburuaeu | capitalize | truncate(50, true, '...') }}</a>
-                        <ul class="dropdown-menu">
+                        <ul class="dropdown-menu scrollable-menu">
                             {% for azpiatala in atala.azpiatalak  if azpiatala.ezabatu != 1 %}
                                 <li class="dropdown dropdown-submenu">
                                     <a href="#{{ atala.kodea ~ azpiatala.kodea }}" class="dropdown-toggle" data-toggle="dropdown" data-clicked="false" onclick="clickMe(this);">{{ azpiatala.kodea }}

--- a/src/AppBundle/Resources/public/css/backend.css
+++ b/src/AppBundle/Resources/public/css/backend.css
@@ -193,3 +193,9 @@ h4  {
 .btnsubmenu:hover {
     border: 1px solid #8c8c8c;
 }
+
+.scrollable-menu {
+    height: auto;
+    max-height: 200px;
+    overflow-x: hidden;
+}


### PR DESCRIPTION
Bi aldaketa nagusi.

Lehenengo, ordenantza baten taula asko dagozanean eta zerrenda lehioan sartzen ez danean, ezin dira taula berriak sartu. Zerrendan scroll egiteko aukera sartu dot. 

Bigarren: Zenbait itzulpen ez ziran erdaraz ateratzen historiko atalean eta konpondu dodaz. Gainera, GAO jarri beharrean literalak aldatu dodaz BO jarriz horrela berdin dau udaletxea Bizkaikoa izatea.